### PR TITLE
Configure CI with Artifactory

### DIFF
--- a/ctm.yaml
+++ b/ctm.yaml
@@ -1,0 +1,3 @@
+ctm:
+  - type: artifactory-maven
+    output: ~/.m2/settings.xml


### PR DESCRIPTION
Configure CircleCI build to automatically generate auth tokens to access
Artifactory. The `ctm.yaml` file will dictate the type of token file
that is needed and where it should be placed on the build filesystem.